### PR TITLE
Optimization and Security

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -10,7 +10,7 @@
     X-Content-Type-Options: nosniff
     Cache-Control: public, max-age=2592000
     Referrer-Policy: strict-origin-when-cross-origin
-    Content-Security-Policy: default-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; report-uri https://hkamran.report-uri.com/r/d/csp/enforce; report-to default
+    Content-Security-Policy: default-src 'self' https://fonts.gstatic.com; connect-src 'self' https://raw.unisontech.org; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; report-uri https://hkamran.report-uri.com/r/d/csp/enforce; report-to default
     Strict-Transport-Security: max-age=31536000; includeSubDomains
 
     

--- a/public/_headers
+++ b/public/_headers
@@ -11,4 +11,6 @@
     Cache-Control: public, max-age=2592000
     Referrer-Policy: strict-origin-when-cross-origin
     Content-Security-Policy: default-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; report-uri https://hkamran.report-uri.com/r/d/csp/enforce; report-to default
+    Strict-Transport-Security: max-age=31536000; includeSubDomains
+
     

--- a/public/_headers
+++ b/public/_headers
@@ -11,6 +11,6 @@
     Cache-Control: public, max-age=2592000
     Referrer-Policy: strict-origin-when-cross-origin
     Content-Security-Policy: default-src 'self' https://fonts.gstatic.com; connect-src 'self' https://raw.unisontech.org; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; report-uri https://hkamran.report-uri.com/r/d/csp/enforce; report-to default
-    Strict-Transport-Security: max-age=31536000; includeSubDomains
+    Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 
     

--- a/public/_headers
+++ b/public/_headers
@@ -10,3 +10,5 @@
     X-Content-Type-Options: nosniff
     Cache-Control: public, max-age=2592000
     Referrer-Policy: strict-origin-when-cross-origin
+    Content-Security-Policy: default-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; report-uri https://hkamran.report-uri.com/r/d/csp/enforce; report-to default
+    

--- a/src/components/CreationCard.vue
+++ b/src/components/CreationCard.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
         :href="props.url"
         target="_blank"
         rel="noopener noreferrer"
-        class="w-full bg-white dark:bg-gray-700 rounded-lg shadow"
+        class="w-full bg-white dark:bg-gray-700 rounded-lg shadow hover:shadow-lg transition"
     >
         <div class="w-full flex items-center justify-between p-6 space-x-6">
             <div class="flex-1">

--- a/src/components/CreationCard.vue
+++ b/src/components/CreationCard.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
         <div class="w-full flex items-center justify-between p-6 space-x-6">
             <div class="flex-1">
                 <div class="flex items-center space-x-3">
-                    <h3
+                    <span
                         class="text-gray-900 dark:text-white text-md font-medium truncate"
                         v-text="props.name"
                     />

--- a/src/components/MainLayout.vue
+++ b/src/components/MainLayout.vue
@@ -1,6 +1,17 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
 const props =
     defineProps<{ header: string; subtitle?: string; typography?: boolean }>();
+
+const mediaQueryMatch = ref<boolean>(
+    window.matchMedia("(min-width: 1024px)").matches,
+);
+const onResize = () =>
+    (mediaQueryMatch.value = window.matchMedia("(min-width: 1024px)").matches);
+
+onMounted(() => window.addEventListener("resize", onResize));
+onBeforeUnmount(() => window.removeEventListener("resize", onResize));
 </script>
 
 <template>
@@ -10,16 +21,41 @@ const props =
                 <div class="flex items-center justify-between h-16">
                     <div class="flex items-center space-x-8">
                         <router-link to="/" class="flex-shrink-0">
-                            <img
-                                class="block lg:hidden h-8 w-auto"
-                                src="/img/logo.png"
-                                alt="UT Logo"
-                            />
-                            <img
-                                class="hidden lg:block h-10 w-auto"
-                                src="/img/wordmark.png"
-                                alt="UT Wordmark"
-                            />
+                            <picture v-if="!mediaQueryMatch" class="block">
+                                <source
+                                    srcset="/img/logo.avif"
+                                    type="image/avif"
+                                />
+                                <source
+                                    srcset="/img/logo.webp"
+                                    type="image/webp"
+                                />
+                                <img
+                                    src="/img/logo.png"
+                                    alt="UNISON Technologies"
+                                    loading="lazy"
+                                    decoding="async"
+                                    class="h-8 w-auto"
+                                />
+                            </picture>
+
+                            <picture v-else class="block">
+                                <source
+                                    srcset="/img/wordmark.avif"
+                                    type="image/avif"
+                                />
+                                <source
+                                    srcset="/img/wordmark.webp"
+                                    type="image/webp"
+                                />
+                                <img
+                                    src="/img/wordmark.png"
+                                    alt="UNISON Technologies"
+                                    loading="lazy"
+                                    decoding="async"
+                                    class="h-10 w-auto"
+                                />
+                            </picture>
                         </router-link>
                     </div>
                 </div>
@@ -40,6 +76,7 @@ const props =
             </div>
         </header>
     </div>
+
     <main class="-mt-32 pb-16">
         <div class="max-w-7xl mx-auto pb-12 px-4 sm:px-8 lg:px-8">
             <div class="bg-white rounded-lg shadow px-5 py-6 sm:px-6 min-h-96">

--- a/src/components/ThreeColumnGrid.vue
+++ b/src/components/ThreeColumnGrid.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="grid md:grid-cols-3 sm:grid-cols-1 grid-flow-row grid-auto-row-dense gap-6"
+        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 grid-flow-row grid-auto-row-dense gap-6"
     >
         <slot />
     </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -82,11 +82,26 @@ export default defineConfig({
                     href: "https://fonts.gstatic.com",
                     crossorigin: "",
                 },
-                {
-                    rel: "stylesheet",
-                    href: "https://fonts.googleapis.com/css2?family=Barlow&display=swap",
-                },
             ],
+            style: `/* latin-ext */
+            @font-face {
+              font-family: 'Barlow';
+              font-style: normal;
+              font-weight: 400;
+              font-display: swap;
+              src: url(https://fonts.gstatic.com/s/barlow/v11/7cHpv4kjgoGqM7E_Ass5ynghnQci.woff2) format('woff2');
+              unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+            }
+            /* latin */
+            @font-face {
+              font-family: 'Barlow';
+              font-style: normal;
+              font-weight: 400;
+              font-display: swap;
+              src: url(https://fonts.gstatic.com/s/barlow/v11/7cHpv4kjgoGqM7E_DMs5ynghnQ.woff2) format('woff2');
+              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+            `,
         }),
         vue(),
     ],


### PR DESCRIPTION
- Switch the logo and wordmark to AVIF and WebP, with a PNG fallback
- Switch the font to a `style`, instead of a `link`
- Switch the service card headers from `h3` to `span`
- Add a `Content-Security-Policy` header
- Add HSTS support through the `Strict-Transport-Security` header